### PR TITLE
Implement cookie repository.

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -6,9 +6,11 @@ import com.google.api.client.json.gson.GsonFactory;
 import greencity.security.filters.AccessTokenAuthenticationFilter;
 import greencity.security.jwt.JwtTool;
 import greencity.security.providers.JwtAuthenticationProvider;
+import greencity.security.repository.CookieAuthorizationRequestRepository;
 import greencity.service.UserService;
 import jakarta.servlet.DispatcherType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -23,7 +25,6 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -51,10 +52,12 @@ public class SecurityConfig {
     private static final String USER_LINK = "/user";
     private final AuthenticationConfiguration authenticationConfiguration;
 
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
     /**
      * Constructor.
      */
-
     @Autowired
     public SecurityConfig(JwtTool jwtTool, UserService userService,
         AuthenticationConfiguration authenticationConfiguration) {
@@ -73,7 +76,7 @@ public class SecurityConfig {
 
     @Bean
     public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
-        return new HttpSessionOAuth2AuthorizationRequestRepository();
+        return new CookieAuthorizationRequestRepository();
     }
 
     /**
@@ -265,8 +268,11 @@ public class SecurityConfig {
      */
     @Bean
     public GoogleIdTokenVerifier googleIdTokenVerifier() {
-        return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(),
-            GsonFactory.getDefaultInstance()).build();
+        return new GoogleIdTokenVerifier.Builder(
+            new NetHttpTransport(),
+            GsonFactory.getDefaultInstance())
+                .setAudience(Collections.singletonList(clientId))
+                .build();
     }
 
     /**

--- a/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
+++ b/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
@@ -99,7 +99,7 @@ public class CookieAuthorizationRequestRepository implements
      */
     private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         String header = String.format("%s=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=Lax",
-                name, value, maxAge);
+            name, value, maxAge);
         response.addHeader("Set-Cookie", header);
     }
 

--- a/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
+++ b/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,157 @@
+package greencity.security.repository;
+
+import greencity.exception.exceptions.CookieDeserializeException;
+import greencity.exception.exceptions.CookieSerializeException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.util.StringUtils;
+import java.io.*;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * Stores and retrieves the OAuth2AuthorizationRequest in an HTTP-only cookie.
+ * This is essential for maintaining state in a stateless application, as it
+ * replaces the default HttpSession-based repository. The authorization request
+ * contains the 'state' parameter for CSRF protection.
+ */
+public class CookieAuthorizationRequestRepository implements
+    AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_COOKIE_NAME = "redirect_uri";
+
+    private static final int COOKIE_MAX_AGE_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map(cookie -> deserialize(cookie, OAuth2AuthorizationRequest.class))
+            .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(
+        OAuth2AuthorizationRequest authorizationRequest,
+        HttpServletRequest request,
+        HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequestCookies(request, response);
+            return;
+        }
+
+        String serializedRequest = serialize(authorizationRequest);
+        addCookie(response,
+            OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            serializedRequest,
+            COOKIE_MAX_AGE_SECONDS);
+
+        String redirectUri = (String) authorizationRequest.getAdditionalParameters()
+            .get(REDIRECT_URI_COOKIE_NAME);
+
+        if (StringUtils.hasText(redirectUri)) {
+            addCookie(response, REDIRECT_URI_COOKIE_NAME, redirectUri, COOKIE_MAX_AGE_SECONDS);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(
+        HttpServletRequest request,
+        HttpServletResponse response) {
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+
+        removeAuthorizationRequestCookies(request, response);
+
+        return authorizationRequest;
+    }
+
+    /**
+     * Deletes the cookies created by this repository.
+     */
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        deleteCookie(request, response, REDIRECT_URI_COOKIE_NAME);
+    }
+
+    /**
+     * Retrieves the cookie with the given name from the request.
+     */
+    private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Adds a new cookie to the response.
+     */
+    private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    /**
+     * Deletes a cookie by setting its maxAge to 0.
+     */
+    private void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        getCookie(request, name).ifPresent(cookie -> {
+            cookie.setValue("");
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+        });
+    }
+
+    /**
+     * Serializes an object to a Base64-encoded string using standard Java
+     * serialization.
+     * 
+     * @param object The object to serialize.
+     * @return The Base64 encoded string.
+     */
+    public String serialize(Serializable object) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(object);
+            oos.flush();
+            return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(bos.toByteArray());
+        } catch (IOException e) {
+            throw new CookieSerializeException("Serialization failed: Could not write object to byte stream.", e);
+        }
+    }
+
+    /**
+     * Deserializes a Base64-encoded string back into an object using standard Java
+     * serialization.
+     * 
+     * @param cookie The cookie containing the Base64 serialized object.
+     * @param cls    The expected class of the deserialized object.
+     * @return The deserialized object.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T deserialize(Cookie cookie, Class<T> cls) {
+        try {
+            byte[] bytes = Base64.getUrlDecoder().decode(cookie.getValue());
+            ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+            ObjectInputStream ois = new ObjectInputStream(bis);
+            return (T) ois.readObject();
+        } catch (IOException | ClassNotFoundException | IllegalArgumentException e) {
+            throw new CookieDeserializeException(
+                "Deserialization failed: Could not read object from byte stream or class not found.", e);
+        }
+    }
+}

--- a/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
+++ b/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
@@ -1,5 +1,7 @@
 package greencity.security.repository;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.exception.exceptions.CookieDeserializeException;
 import greencity.exception.exceptions.CookieSerializeException;
 import jakarta.servlet.http.Cookie;
@@ -10,6 +12,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.util.StringUtils;
 import java.io.*;
 import java.util.Base64;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -24,6 +27,7 @@ public class CookieAuthorizationRequestRepository implements
     public static final String REDIRECT_URI_COOKIE_NAME = "redirect_uri";
 
     private static final int COOKIE_MAX_AGE_SECONDS = 180;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
@@ -123,14 +127,20 @@ public class CookieAuthorizationRequestRepository implements
      */
     public String serialize(Serializable object) {
         try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream oos = new ObjectOutputStream(bos);
-            oos.writeObject(object);
-            oos.flush();
+            OAuth2AuthorizationRequest o = (OAuth2AuthorizationRequest) object;
+            Map<String, Object> payload = Map.of(
+                "authorizationUri", o.getAuthorizationUri(),
+                "clientId", o.getClientId(),
+                "redirectUri", o.getRedirectUri(),
+                "scopes", o.getScopes(),
+                "state", o.getState(),
+                "attributes", o.getAttributes(),
+                "additionalParameters", o.getAdditionalParameters());
+            String json = MAPPER.writeValueAsString(payload);
             return Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(bos.toByteArray());
-        } catch (IOException e) {
-            throw new CookieSerializeException("Serialization failed: Could not write object to byte stream.", e);
+                .encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        } catch (IOException | ClassCastException e) {
+            throw new CookieSerializeException("Serialization failed.", e);
         }
     }
 
@@ -142,16 +152,31 @@ public class CookieAuthorizationRequestRepository implements
      * @param cls    The expected class of the deserialized object.
      * @return The deserialized object.
      */
-    @SuppressWarnings("unchecked")
     public <T> T deserialize(Cookie cookie, Class<T> cls) {
         try {
             byte[] bytes = Base64.getUrlDecoder().decode(cookie.getValue());
-            ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
-            ObjectInputStream ois = new ObjectInputStream(bis);
-            return (T) ois.readObject();
-        } catch (IOException | ClassNotFoundException | IllegalArgumentException e) {
-            throw new CookieDeserializeException(
-                "Deserialization failed: Could not read object from byte stream or class not found.", e);
+            String json = new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+            Map<String, Object> p = MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {
+            });
+
+            @SuppressWarnings("unchecked")
+            OAuth2AuthorizationRequest result =
+                OAuth2AuthorizationRequest.authorizationCode()
+                    .authorizationUri((String) p.get("authorizationUri"))
+                    .clientId((String) p.get("clientId"))
+                    .redirectUri((String) p.get("redirectUri"))
+                    .scopes(new java.util.HashSet<>((java.util.List<String>) p.get("scopes")))
+                    .state((String) p.get("state"))
+                    .attributes((Map<String, Object>) p.getOrDefault("attributes", Map.of()))
+                    .additionalParameters((Map<String, Object>) p.getOrDefault("additionalParameters", Map.of()))
+                    .build();
+
+            if (!cls.isInstance(result)) {
+                throw new CookieDeserializeException("Unexpected deserialized type: " + result.getClass(), null);
+            }
+            return cls.cast(result);
+        } catch (IOException | ClassCastException | IllegalArgumentException e) {
+            throw new CookieDeserializeException("Deserialization failed.", e);
         }
     }
 }

--- a/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
+++ b/core/src/main/java/greencity/security/repository/CookieAuthorizationRequestRepository.java
@@ -98,12 +98,9 @@ public class CookieAuthorizationRequestRepository implements
      * Adds a new cookie to the response.
      */
     private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
+        String header = String.format("%s=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=Lax",
+                name, value, maxAge);
+        response.addHeader("Set-Cookie", header);
     }
 
     /**
@@ -113,8 +110,11 @@ public class CookieAuthorizationRequestRepository implements
         getCookie(request, name).ifPresent(cookie -> {
             cookie.setValue("");
             cookie.setPath("/");
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
             cookie.setMaxAge(0);
-            response.addCookie(cookie);
+            String header = String.format("%s=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax", name);
+            response.addHeader("Set-Cookie", header);
         });
     }
 

--- a/core/src/test/java/greencity/security/repository/CookieAuthorizationRequestRepositoryTest.java
+++ b/core/src/test/java/greencity/security/repository/CookieAuthorizationRequestRepositoryTest.java
@@ -56,6 +56,7 @@ class CookieAuthorizationRequestRepositoryTest {
             getResponseCookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
         assertNotNull(authCookie, "Auth Request cookie must be set");
         assertTrue(authCookie.isHttpOnly(), "Cookie must be HTTP-only for security");
+        assertTrue(authCookie.getSecure(), "Cookie must be Secure");
         assertEquals("/", authCookie.getPath(), "Cookie path must be root");
         assertEquals(180, authCookie.getMaxAge(), "Cookie max age must be 180 seconds");
     }

--- a/core/src/test/java/greencity/security/repository/CookieAuthorizationRequestRepositoryTest.java
+++ b/core/src/test/java/greencity/security/repository/CookieAuthorizationRequestRepositoryTest.java
@@ -1,0 +1,121 @@
+package greencity.security.repository;
+
+import greencity.exception.exceptions.CookieDeserializeException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponseType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the CookieAuthorizationRequestRepository. Verifies that OAuth2
+ * authorization requests are correctly saved to, loaded from, and removed from
+ * HTTP cookies.
+ */
+class CookieAuthorizationRequestRepositoryTest {
+    private CookieAuthorizationRequestRepository repository;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    private static final OAuth2AuthorizationRequest MOCK_AUTH_REQUEST = OAuth2AuthorizationRequest.authorizationCode()
+        .authorizationUri("https://example.com/oauth/authorize")
+        .clientId("client-id")
+        .redirectUri("http://localhost:8080/auth/google/callback")
+        .scopes(Collections.singleton("openid"))
+        .state("test-state-1234")
+        .attributes(Map.of(OAuth2ParameterNames.RESPONSE_TYPE, OAuth2AuthorizationResponseType.CODE.getValue()))
+        .build();
+
+    @BeforeEach
+    void setUp() {
+        repository = new CookieAuthorizationRequestRepository();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    /**
+     * Helper to get a cookie by name from the response.
+     */
+    private Cookie getResponseCookie(String name) {
+        return response.getCookie(name);
+    }
+
+    @Test
+    void testSaveAuthorizationRequest_shouldSetCookie() {
+        repository.saveAuthorizationRequest(MOCK_AUTH_REQUEST, request, response);
+
+        Cookie authCookie =
+            getResponseCookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        assertNotNull(authCookie, "Auth Request cookie must be set");
+        assertTrue(authCookie.isHttpOnly(), "Cookie must be HTTP-only for security");
+        assertEquals("/", authCookie.getPath(), "Cookie path must be root");
+        assertEquals(180, authCookie.getMaxAge(), "Cookie max age must be 180 seconds");
+    }
+
+    @Test
+    void testSaveNullAuthorizationRequest_shouldRemoveCookies() {
+        request.setCookies(
+            new Cookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "dummy"),
+            new Cookie(CookieAuthorizationRequestRepository.REDIRECT_URI_COOKIE_NAME, "dummy"));
+
+        repository.saveAuthorizationRequest(null, request, response);
+
+        assertEquals(0, getResponseCookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .getMaxAge());
+        assertEquals(0, getResponseCookie(CookieAuthorizationRequestRepository.REDIRECT_URI_COOKIE_NAME).getMaxAge());
+    }
+
+    @Test
+    void testLoadAuthorizationRequest_shouldLoadFromCookie() {
+        String serializedRequest = repository.serialize(MOCK_AUTH_REQUEST);
+        request.setCookies(
+            new Cookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                serializedRequest));
+
+        OAuth2AuthorizationRequest loadedRequest = repository.loadAuthorizationRequest(request);
+
+        assertNotNull(loadedRequest, "Loaded request should not be null");
+        assertEquals(MOCK_AUTH_REQUEST.getState(), loadedRequest.getState(), "State must match");
+        assertEquals(MOCK_AUTH_REQUEST.getAuthorizationUri(), loadedRequest.getAuthorizationUri(), "URI must match");
+    }
+
+    @Test
+    void testLoadAuthorizationRequest_shouldReturnNullWhenNoCookie() {
+        assertNull(repository.loadAuthorizationRequest(request), "Should return null if no cookie is present");
+    }
+
+    @Test
+    void testLoadThrowsCookieDeserializeException_forCorruptCookie() {
+        request.setCookies(
+            new Cookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                "not-a-valid-serialized-object"));
+
+        assertThrows(CookieDeserializeException.class, () -> repository.loadAuthorizationRequest(request),
+            "Loading a corrupt cookie must throw CookieDeserializeException");
+    }
+
+    @Test
+    void testRemoveAuthorizationRequest_shouldRemoveCookiesAndReturnRequest() {
+        String serializedRequest = repository.serialize(MOCK_AUTH_REQUEST);
+        request.setCookies(
+            new Cookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                serializedRequest));
+
+        OAuth2AuthorizationRequest removedRequest = repository.removeAuthorizationRequest(request, response);
+
+        assertNotNull(removedRequest, "Removed request should return the loaded request object");
+        assertEquals(MOCK_AUTH_REQUEST.getState(), removedRequest.getState(),
+            "The returned request state must match original");
+
+        assertEquals(0, getResponseCookie(CookieAuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .getMaxAge());
+    }
+}

--- a/service-api/src/main/java/greencity/exception/exceptions/CookieDeserializeException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/CookieDeserializeException.java
@@ -1,0 +1,7 @@
+package greencity.exception.exceptions;
+
+public class CookieDeserializeException extends RuntimeException {
+    public CookieDeserializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/service-api/src/main/java/greencity/exception/exceptions/CookieSerializeException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/CookieSerializeException.java
@@ -1,0 +1,7 @@
+package greencity.exception.exceptions;
+
+public class CookieSerializeException extends RuntimeException {
+    public CookieSerializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
- Add custom cookie repository CookieAuthorizationRequestRepository.
- Add tests for said repository.
- Add exceptions for Serialization / Deserializaion exceptions.
- Change SpringSecurity:
  - Add clientId and insert audience check into GoogleIdTokenVerifier.
  - AuthorizationRequestRepository should now return new CookieAuthorizationRequestRepository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OAuth2 sign-in now persists authorization state in secure, HTTP-only cookies for more reliable redirects.
  - Google sign-in token verification now validates against the configured client ID.
  - Added dedicated errors for cookie serialization/deserialization to improve error reporting.

- Refactor
  - Replaced session-based storage of OAuth2 authorization requests with cookie-based storage.

- Tests
  - Added unit tests for saving, loading, removing, and handling corrupt/absent OAuth2 cookies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->